### PR TITLE
更新 njuthesis

### DIFF
--- a/data/thesis.json
+++ b/data/thesis.json
@@ -164,10 +164,10 @@
       "package_name": "njuthesis",
       "institution_name": "南京大学",
       "maintainer_type": "组织",
-      "github_repository": "github.com/njuHan/njuthesis-nju-thesis-template",
+      "github_repository": "github.com/nju-lug/NJUThesis",
       "gitlab_repository": "",
       "gitee_repository": "",
-      "ctan_package": "",
+      "ctan_package": "njuthesis",
       "status": ""
     },
     {

--- a/data/thesis.json
+++ b/data/thesis.json
@@ -167,7 +167,7 @@
       "github_repository": "github.com/nju-lug/NJUThesis",
       "gitlab_repository": "",
       "gitee_repository": "",
-      "ctan_package": "njuthesis",
+      "ctan_package": "ctan.org/pkg/njuthesis",
       "status": ""
     },
     {


### PR DESCRIPTION
`github.com/nju-lug/NJUThesis`是一个集大成版本，由NJU Linux User Group维护，已被CTAN收录。